### PR TITLE
Move Gulp to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
     "chai": "^3.5.0",
     "eslint": "^3.12.2",
     "eslint-config-volebo": "^2.0.0",
+    "gulp": "^3.9.1",
+    "gulp-bump": "^2.5.1",
+    "gulp-git": "^1.12.0",
+    "gulp-tag-version": "^1.3.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"
   },
   "dependencies": {
     "debug": "^2.5.1",
-    "gulp": "^3.9.1",
-    "gulp-bump": "^2.5.1",
-    "gulp-git": "^1.12.0",
-    "gulp-tag-version": "^1.3.0",
     "request": "^2.79.0"
   }
 }


### PR DESCRIPTION
I moved `gulp` to dev-dependencies, bcz it is not required for common consumer of this package