### PR TITLE
Extend the debug info in thrown Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ This is the history of changes of the `freshdesk-api` package
 
 ## unreleased // ???
 
-* ??
+* Error Handling: filter for errors on JSON-parse, now it handles on JSON errors
+* Error Handling: `apiTarget` field on FreshdeskError, containing the name of method and requested URL of the API
+* Error Handling: HTTP status **404** handled correctly (there is an empty body)
+* Test: added test for network errors
+
+Fixed:
+
+* bug `response.request is not defined`, caused by network-errors, in the `debug` call
 
 ## 2017-01-06 // 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,23 @@
 
 This is the history of changes of the `freshdesk-api` package
 
-> If you want to add something to this file, please, follow this [guide](http://keepachangelog.com/en/0.3.0/)
+> This file should be filled by maintainers, using pull requests
+> Please, follow this [guide](http://keepachangelog.com/en/0.3.0/)
 
 ## unreleased // ???
 
+* ??
+
+## 2017-01-06 // 2.0.1
+
+* `status` property on FreshdeskError
+* more tests
+
 ## 2017-01-04 // 1.1.1
 
-Published APIv1 version `1.1.1`, using sources provided by Kumar Harsh (@kumarharsh, https://github.com/kumarharsh)
-
-This version marked as deprecated in favor of version 2.0.0
+* Published APIv1 version `1.1.1`, using sources provided by Kumar Harsh (@kumarharsh, https://github.com/kumarharsh)
+* This version marked as deprecated in favor of version 2.0.0
 
 ## 2017-01-02 // 2.0.0-beta.2
-
-fixed
 
 * Attach RAW data to FreshdeskError, when `JSON.parse` can't parse body of the request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This is the history of changes of the `freshdesk-api` package
 
 ## unreleased // ???
 
+## 2017-01-07 // 2.1.0
+
 * Error Handling: filter for errors on JSON-parse, now it handles on JSON errors
 * Error Handling: `apiTarget` field on FreshdeskError, containing the name of method and requested URL of the API
 * Error Handling: HTTP status **404** handled correctly (there is an empty body)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Node Freshdesk SDK [![Build Status](https://travis-ci.org/arjunkomath/node-freshdesk-api.svg?branch=master)](https://travis-ci.org/arjunkomath/node-freshdesk-api)
+# Node Freshdesk SDK
+
+[![Build Status](https://travis-ci.org/arjunkomath/node-freshdesk-api.svg?branch=master)](https://travis-ci.org/arjunkomath/node-freshdesk-api)
+[![codecov](https://codecov.io/gh/arjunkomath/node-freshdesk-api/branch/master/graph/badge.svg)](https://codecov.io/gh/arjunkomath/node-freshdesk-api)
+
 Node wrapper for [Freshdesk v2 API](http://developer.freshdesk.com/api/#introduction)
 
 [![NPM](https://nodei.co/npm/freshdesk-api.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/freshdesk-api/)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,21 +21,23 @@ http://spdx.org/licenses/MIT
 const request = require('request');
 const debug = require('debug')('freshdesk-api');
 
-
 /**
  * Freshdesk's API protocol violations
  *
- * @param {[type]} message [description]
- * @param {[type]} data    [description]
+ * @param {string}  message Error message
+ * @param {integer} status  HTTP status of the received Freshdesk-response. Could be useful for debugging
+ * @param {Object}  data    Parsed response of the Freshdesk API
  */
-function FreshdeskError(message, data) {
-	this.name = 'FreshdeskError';
-	this.message = message || 'Error in Freshdesk\'s client API';
-	this.stack = (new Error()).stack;
-	this.data = data;
+function FreshdeskError(message, status, data) {
+	this.name = 'FreshdeskError'
+	this.message = message || 'Error in Freshdesk\'s client API'
+	this.stack = (new Error()).stack
+
+	this.status = status
+	this.data = data
 }
-FreshdeskError.prototype = Object.create(Error.prototype);
-FreshdeskError.prototype.constructor = FreshdeskError;
+FreshdeskError.prototype = Object.create(Error.prototype)
+FreshdeskError.prototype.constructor = FreshdeskError
 
 
 function createResponseHandler (cb) {
@@ -58,7 +60,7 @@ function createResponseHandler (cb) {
 			} catch (err) {
 				// TODO: catch only JSON-parse errors!!!
 				debug(`Not a JSON resp with valid status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-				return cb(new FreshdeskError('Not a JSON response from API', body));
+				return cb(new FreshdeskError('Not a JSON response from API', response.statusCode, body));
 			}
 			return cb(null, data)
 
@@ -77,11 +79,11 @@ function createResponseHandler (cb) {
 
 				// probably, data is not a JSON, so lets return it "AS IS"
 				debug(`Not a JSON resp for unexpected status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-				return cb(new FreshdeskError('Not a JSON response from API', body))
+				return cb(new FreshdeskError('Not a JSON response from API', response.statusCode, body))
 			}
 
 			debug(`Unexpected/Error status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-			return cb(new FreshdeskError(data.description, data))
+			return cb(new FreshdeskError(data.description, response.statusCode, data))
 		}
 	}
 }
@@ -105,5 +107,5 @@ function makeRequest(method, auth, url, qs, data, cb) {		// eslint-disable-line 
 	request(options, createResponseHandler(cb))
 }
 
-module.exports.makeRequest = makeRequest;
-module.exports.FreshdeskError = FreshdeskError;
+module.exports.makeRequest = makeRequest
+module.exports.FreshdeskError = FreshdeskError

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,10 +16,10 @@ program. If not, see <https://opensource.org/licenses/MIT>.
 http://spdx.org/licenses/MIT
 */
 
-"use strict";
+"use strict"
 
-const request = require('request');
-const debug = require('debug')('freshdesk-api');
+const request = require('request')
+const debug = require('debug')('freshdesk-api')
 
 /**
  * Freshdesk's API protocol violations
@@ -28,13 +28,15 @@ const debug = require('debug')('freshdesk-api');
  * @param {integer} status  HTTP status of the received Freshdesk-response. Could be useful for debugging
  * @param {Object}  data    Parsed response of the Freshdesk API
  */
-function FreshdeskError(message, status, data) {
+function FreshdeskError(message, data, res) {
 	this.name = 'FreshdeskError'
 	this.message = message || 'Error in Freshdesk\'s client API'
 	this.stack = (new Error()).stack
 
-	this.status = status
 	this.data = data
+
+	this.status = res.statusCode
+	this.apiTarget = `${res.request.method} ${res.request.uri.href}`
 }
 FreshdeskError.prototype = Object.create(Error.prototype)
 FreshdeskError.prototype.constructor = FreshdeskError
@@ -43,11 +45,17 @@ FreshdeskError.prototype.constructor = FreshdeskError
 function createResponseHandler (cb) {
 	return function (error, response, body) {
 		if (error) {
-			debug(`Unexpected status [${error}], req path [${response.request.path}] raw body: ${response.request.body}`);
-			return cb(error);
+			debug('Error on request: [%s], req path [%s] raw body: %o',
+				error,
+				response ? response.request.path : undefined,
+				response ? response.request.body : undefined
+			)
+			return cb(error)
 		}
 
 		let data = null;
+
+		debug('Got API response, status [%s]', response.statusCode)
 
 		switch(response.statusCode) {
 		// SUCCESS
@@ -58,9 +66,17 @@ function createResponseHandler (cb) {
 			try {
 				data = JSON.parse(body)
 			} catch (err) {
-				// TODO: catch only JSON-parse errors!!!
-				debug(`Not a JSON resp with valid status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-				return cb(new FreshdeskError('Not a JSON response from API', response.statusCode, body));
+				if (err instanceof SyntaxError) {
+					debug('Valid HTTP status [%s], but not a JSON resp. Path:[%s] raw body: %o',
+						response.statusCode,
+						response.request.path,
+						response.request.body
+					)
+					return cb(new FreshdeskError('Not a JSON response from API', body, response))
+				}
+
+				// unknown error
+				throw err
 			}
 			return cb(null, data)
 
@@ -69,21 +85,47 @@ function createResponseHandler (cb) {
 		case 204:
 			return cb(null, null);
 
+		// https://httpstatuses.com/404 Not found
+		case 404:
+			debug('path:[%s] raw body: %o',
+				response.request.path,
+				response.request.body
+			)
+
+			// In most casses 404 means, that there is no such entity on requested
+			// Freshdesk domain. For example, you are trying to update non-existent
+			// contact
+			// But, it also could be a result of wrong URL (?!?!?)
+			//
+			// In most cases the body is EMPTY, so we will just warn about wrong entity
+			return cb(new FreshdeskError('The requested entity was not found', data, response))
+
 		// https://httpstatuses.com/409 Conflict  - NOT UNIQUE, where unique required
 		case 409:
 		default:
+			debug('path:[%s] raw body: %o',
+				response.request.path,
+				response.request.body
+			)
+
 			try {
 				data = JSON.parse(body)
 			} catch (err) {
-				// TODO: catch only JSON-parse errors!!!
+				if (err instanceof SyntaxError) {
+					// data is not a JSON, so lets return it "AS IS"
+					debug('Unexpected HTTP status [%s], and not a JSON resp. Path:[%s] raw body: %o',
+						response.statusCode,
+						response.request.path,
+						response.request.body
+					)
+					return cb(new FreshdeskError('Not a JSON response from API', body, response))
+				}
 
-				// probably, data is not a JSON, so lets return it "AS IS"
-				debug(`Not a JSON resp for unexpected status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-				return cb(new FreshdeskError('Not a JSON response from API', response.statusCode, body))
+				// unknown error
+				throw err
 			}
 
-			debug(`Unexpected/Error status [${response.statusCode}], req path [${response.request.path}] raw body: ${response.request.body}`);
-			return cb(new FreshdeskError(data.description, response.statusCode, data))
+			return cb(new FreshdeskError(data.description, data, response))
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk-api",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Node wrapper for Freshdesk v2 API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
       "name": "Koryukov Maksim",
       "email": "maxkoryukov@gmail.com",
       "url": "https://www.npmjs.com/~maxkoryukov"
-    }, {
+    },
+    {
       "name": "Kumar Harsh",
       "email": "khs@playlyfe.com",
       "url": "https://github.com/kumarharsh"
@@ -48,7 +49,8 @@
     "gulp-git": "^1.12.0",
     "gulp-tag-version": "^1.3.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "nock": "^9.0.2"
   },
   "dependencies": {
     "debug": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk-api",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.1",
   "description": "Node wrapper for Freshdesk v2 API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "freshdesk",
+    "v1",
     "v2",
     "api",
     "node",

--- a/test/api.contact.test.js
+++ b/test/api.contact.test.js
@@ -1,0 +1,84 @@
+/*
+Node wrapper for Freshdesk v2 API
+
+Copyright (C) 2016-2017 Maksim Koryukov <maxkoryukov@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License, attached to this software package.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+You should have received a copy of the MIT License along with this
+program. If not, see <https://opensource.org/licenses/MIT>.
+
+http://spdx.org/licenses/MIT
+*/
+
+"use strict";
+
+const nock = require('nock')
+
+const Freshdesk = require('..')
+
+describe('api.contact', function(){
+
+	let freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
+
+	describe('update', () => {
+
+		it('should send PUT request to /api/v2/contacts/NNNN', (done) => {
+
+			const res = {
+				"id":22000991607,
+				"deleted":false,
+				"description":null,
+				"email":"gwuzi@mail.ru",
+				"name":"Clark Kent"
+			}
+
+			// SET UP expected request
+
+			nock('https://test.freshdesk.com')
+				.put('/api/v2/contacts/22000991607', {
+					"name": "Clark Kent"
+				})
+				.reply(200, res)
+
+
+			freshdesk.updateContact(22000991607, {"name":"Clark Kent"}, (err, data) => {
+				expect(err).is.null
+				expect(data).to.deep.equal(res)
+				done()
+			})
+		})
+	})
+
+	describe('get', () => {
+
+		it('should send GET request to /api/v2/contacts/NNNN', (done) => {
+
+			const res = {
+				"id":22000991607,
+				"deleted":false,
+				"description":null,
+				"email":"gwuzi@mail.ru",
+				"name":"Clark Kent"
+			}
+
+			// SET UP expected request
+
+			nock('https://test.freshdesk.com')
+				.get('/api/v2/contacts/22000991607')
+				.reply(200, res)
+
+
+			freshdesk.getContact(22000991607, (err, data) => {
+				expect(err).is.null
+				expect(data).to.deep.equal(res)
+				done()
+			})
+		})
+	})
+})

--- a/test/api.error.test.js
+++ b/test/api.error.test.js
@@ -33,18 +33,42 @@ describe('api.error', function(){
 
 		before(()=>{
 			nock('https://test.freshdesk.com')
-				.get('/api/v2/companies/0')
+				.get(/.*/)
 				.reply(400, {msg:"err 123"})
 		})
 
-		it('should throw FreshdeskError', (done) => {
+		it('should pass FreshdeskError to callback', (done) => {
 
-			freshdesk.getCompany(0, (err) => {
+			freshdesk.getCompany(2139, (err) => {
 				expect(err).is.not.null
 				expect(err).to.be.instanceof(Freshdesk.FreshdeskError)
 				expect(err).has.property('status', 400)
 				expect(err).has.property('message', "Error in Freshdesk's client API")
 				expect(err).has.property('data').to.deep.equal({msg: "err 123"})
+				expect(err).has.property('apiTarget').to.equal('GET https://test.freshdesk.com/api/v2/companies/2139')
+
+				done()
+			})
+
+			//throw(Freshdesk.FreshdeskError)
+		})
+	})
+
+
+	describe('on network error', () => {
+
+		before(()=>{
+			nock('https://test.freshdesk.com')
+				.get(/.*/)
+				.replyWithError('my network error')
+		})
+
+		it('should pass Error to callback', (done) => {
+
+			freshdesk.getTicket(111, (err) => {
+				expect(err).is.not.null
+				expect(err).to.be.instanceof(Error)
+				expect(err).has.property('message', "my network error")
 
 				done()
 			})

--- a/test/api.error.test.js
+++ b/test/api.error.test.js
@@ -39,7 +39,7 @@ describe('api.error', function(){
 
 		it('should throw FreshdeskError', (done) => {
 
-			freshdesk.getCompany(0, (err, res) => {
+			freshdesk.getCompany(0, (err) => {
 				expect(err).is.not.null
 				expect(err).to.be.instanceof(Freshdesk.FreshdeskError)
 				expect(err).has.property('status', 400)

--- a/test/api.error.test.js
+++ b/test/api.error.test.js
@@ -1,0 +1,55 @@
+/*
+Node wrapper for Freshdesk v2 API
+
+Copyright (C) 2016-2017 Maksim Koryukov <maxkoryukov@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the MIT License, attached to this software package.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+You should have received a copy of the MIT License along with this
+program. If not, see <https://opensource.org/licenses/MIT>.
+
+http://spdx.org/licenses/MIT
+*/
+
+"use strict";
+
+const nock = require('nock')
+
+const Freshdesk = require('..')
+
+describe('api.error', function(){
+
+	//this.timeout(5000)
+	//this.slow(3000)
+
+	let freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
+
+	describe('on API response status 400', () => {
+
+		before(()=>{
+			nock('https://test.freshdesk.com')
+				.get('/api/v2/companies/0')
+				.reply(400, {msg:"err 123"})
+		})
+
+		it('should throw FreshdeskError', (done) => {
+
+			freshdesk.getCompany(0, (err, res) => {
+				expect(err).is.not.null
+				expect(err).to.be.instanceof(Freshdesk.FreshdeskError)
+				expect(err).has.property('status', 400)
+				expect(err).has.property('message', "Error in Freshdesk's client API")
+				expect(err).has.property('data').to.deep.equal({msg: "err 123"})
+
+				done()
+			})
+
+			//throw(Freshdesk.FreshdeskError)
+		})
+	})
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,6 +2,5 @@
 --recursive
 --check-leaks
 --ui bdd
---prof
 --require test/bootstrap
 test/**/*.test.js


### PR DESCRIPTION
The `status` field added to the `FreshdeskError` class

Dramatically increased test-coverage (https://codecov.io/gh/arjunkomath/node-freshdesk-api)