### PR TITLE
Expose pagination from headers 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ http://spdx.org/licenses/MIT
 "use strict"
 
 const request = require('request')
+const parse = require('parse-link-header')
 const debug = require('debug')('freshdesk-api')
 
 /**
@@ -64,7 +65,9 @@ function createResponseHandler (cb) {
 		case 200:
 		case 201:
 			try {
-				data = JSON.parse(body)
+				data = Object.assign({
+					data: JSON.parse(body)
+				}, response.headers.link && parse(response.headers.link))
 			} catch (err) {
 				if (err instanceof SyntaxError) {
 					debug('Valid HTTP status [%s], but not a JSON resp. Path:[%s] raw body: %o',
@@ -109,7 +112,9 @@ function createResponseHandler (cb) {
 			)
 
 			try {
-				data = JSON.parse(body)
+				data = Object.assign({
+					data: JSON.parse(body)
+				}, response.headers.link && parse(response.headers.link))
 			} catch (err) {
 				if (err instanceof SyntaxError) {
 					// data is not a JSON, so lets return it "AS IS"
@@ -132,7 +137,7 @@ function createResponseHandler (cb) {
 
 // TODO: try to make less params here
 function makeRequest(method, auth, url, qs, data, cb) {		// eslint-disable-line max-params
-	var options = {
+	const options = {
 		method: method,
 		headers: {
 			'Content-Type': 'application/json',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,9 +18,8 @@ http://spdx.org/licenses/MIT
 
 "use strict"
 
-const request = require('request')
-const parse = require('parse-link-header')
-const debug = require('debug')('freshdesk-api')
+const request         = require('request')
+const debug           = require('debug')('freshdesk-api')
 
 /**
  * Freshdesk's API protocol violations
@@ -54,9 +53,22 @@ function createResponseHandler (cb) {
 			return cb(error)
 		}
 
-		let data = null;
+		let data = null
+		const extra = {
+			pageIsLast: true
+		}
 
 		debug('Got API response, status [%s]', response.statusCode)
+
+		if (response
+			&& response.headers
+			&& 'string' === typeof response.headers.link
+		) {
+			debug('Detected http-header LINK, page is not last', response.headers.link)
+			extra.pageIsLast = false
+			// TODO: reconsider this property
+			extra._headersLink = extra.pageIsLast
+		}
 
 		switch(response.statusCode) {
 		// SUCCESS
@@ -65,9 +77,7 @@ function createResponseHandler (cb) {
 		case 200:
 		case 201:
 			try {
-				data = Object.assign({
-					data: JSON.parse(body)
-				}, response.headers.link && parse(response.headers.link))
+				data = JSON.parse(body)
 			} catch (err) {
 				if (err instanceof SyntaxError) {
 					debug('Valid HTTP status [%s], but not a JSON resp. Path:[%s] raw body: %o',
@@ -79,14 +89,14 @@ function createResponseHandler (cb) {
 				}
 
 				// unknown error
-				throw err
+				return cb(err)
 			}
-			return cb(null, data)
+			return cb(null, data, extra)
 
 		// SUCCESS for DELETE operations
 		// https://httpstatuses.com/204 No Content
 		case 204:
-			return cb(null, null);
+			return cb(null, null, extra)
 
 		// https://httpstatuses.com/404 Not found
 		case 404:
@@ -112,9 +122,7 @@ function createResponseHandler (cb) {
 			)
 
 			try {
-				data = Object.assign({
-					data: JSON.parse(body)
-				}, response.headers.link && parse(response.headers.link))
+				data = JSON.parse(body)
 			} catch (err) {
 				if (err instanceof SyntaxError) {
 					// data is not a JSON, so lets return it "AS IS"
@@ -127,7 +135,7 @@ function createResponseHandler (cb) {
 				}
 
 				// unknown error
-				throw err
+				return cb(err)
 			}
 
 			return cb(new FreshdeskError(data.description, data, response))

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "debug": "^2.5.1",
-    "parse-link-header": "^0.4.1",
     "request": "^2.79.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "debug": "^2.5.1",
+    "parse-link-header": "^0.4.1",
     "request": "^2.79.0"
   },
   "publishConfig": {

--- a/test/api.contact.test.js
+++ b/test/api.contact.test.js
@@ -31,13 +31,11 @@ describe('api.contact', function(){
 		it('should send PUT request to /api/v2/contacts/NNNN', (done) => {
 
 			const res = {
-				data: {
-					"id":22000991607,
-					"deleted":false,
-					"description":null,
-					"email":"gwuzi@mail.ru",
-					"name":"Clark Kent"
-				}
+				"id":22000991607,
+				"deleted":false,
+				"description":null,
+				"email":"gwuzi@mail.ru",
+				"name":"Clark Kent"
 			}
 
 			// SET UP expected request
@@ -49,9 +47,10 @@ describe('api.contact', function(){
 				.reply(200, res)
 
 
-			freshdesk.updateContact(22000991607, {"name":"Clark Kent"}, (err, data) => {
+			freshdesk.updateContact(22000991607, {"name": "Clark Kent"}, (err, data, extra) => {
 				expect(err).is.null
-				expect(data.data).to.deep.equal(res)
+				expect(data).to.deep.equal(res)
+				expect(extra).to.exist
 				done()
 			})
 		})
@@ -62,13 +61,11 @@ describe('api.contact', function(){
 		it('should send GET request to /api/v2/contacts/NNNN', (done) => {
 
 			const res = {
-				data: {
-					"id":22000991607,
-					"deleted":false,
-					"description":null,
-					"email":"gwuzi@mail.ru",
-					"name":"Clark Kent"
-				}
+				"id":22000991607,
+				"deleted":false,
+				"description":null,
+				"email":"gwuzi@mail.ru",
+				"name":"Clark Kent"
 			}
 
 			// SET UP expected request
@@ -78,9 +75,57 @@ describe('api.contact', function(){
 				.reply(200, res)
 
 
-			freshdesk.getContact(22000991607, (err, data) => {
+			freshdesk.getContact(22000991607, (err, data, extra) => {
 				expect(err).is.null
-				expect(data.data).to.deep.equal(res)
+				expect(data).to.deep.equal(res)
+				expect(extra).to.exist
+				done()
+			})
+		})
+	})
+
+	describe('listAllContacts', () => {
+
+		it('should send GET request to /api/v2/contacts', (done) => {
+
+			const res = [
+				{
+					"id":22000991607,
+					"deleted":false,
+					"description":null,
+					"email":"gwuzi@mail.ru",
+					"name":"Clark Kent"
+				}, {
+					"id":22000991608,
+					"deleted":false,
+					"description":null,
+					"email":"donna@example.com",
+					"name":"Donna Example"
+				}
+
+			]
+
+			// SET UP expected request
+
+			nock('https://test.freshdesk.com')
+				.get('/api/v2/contacts')
+				.query({"page": 12, "per_page": 10})
+				.reply(200, res, {
+					"link": '< https://test.freshdesk.com/api/v2/contacts?page=13&per_page=10>;rel="next"',
+				})
+
+			const options = {
+				"page": 12,
+				"per_page": 10,
+			}
+
+			freshdesk.listAllContacts(options, (err, data, extra) => {
+				expect(err).is.null
+				expect(data).to.deep.equal(res)
+				expect(extra).to.exist
+				expect(extra).to.be.an('object')
+					.that.have.property('pageIsLast', false)
+
 				done()
 			})
 		})

--- a/test/api.contact.test.js
+++ b/test/api.contact.test.js
@@ -24,18 +24,20 @@ const Freshdesk = require('..')
 
 describe('api.contact', function(){
 
-	let freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
+	const freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
 
 	describe('update', () => {
 
 		it('should send PUT request to /api/v2/contacts/NNNN', (done) => {
 
 			const res = {
-				"id":22000991607,
-				"deleted":false,
-				"description":null,
-				"email":"gwuzi@mail.ru",
-				"name":"Clark Kent"
+				data: {
+					"id":22000991607,
+					"deleted":false,
+					"description":null,
+					"email":"gwuzi@mail.ru",
+					"name":"Clark Kent"
+				}
 			}
 
 			// SET UP expected request
@@ -49,7 +51,7 @@ describe('api.contact', function(){
 
 			freshdesk.updateContact(22000991607, {"name":"Clark Kent"}, (err, data) => {
 				expect(err).is.null
-				expect(data).to.deep.equal(res)
+				expect(data.data).to.deep.equal(res)
 				done()
 			})
 		})
@@ -60,11 +62,13 @@ describe('api.contact', function(){
 		it('should send GET request to /api/v2/contacts/NNNN', (done) => {
 
 			const res = {
-				"id":22000991607,
-				"deleted":false,
-				"description":null,
-				"email":"gwuzi@mail.ru",
-				"name":"Clark Kent"
+				data: {
+					"id":22000991607,
+					"deleted":false,
+					"description":null,
+					"email":"gwuzi@mail.ru",
+					"name":"Clark Kent"
+				}
 			}
 
 			// SET UP expected request
@@ -76,7 +80,7 @@ describe('api.contact', function(){
 
 			freshdesk.getContact(22000991607, (err, data) => {
 				expect(err).is.null
-				expect(data).to.deep.equal(res)
+				expect(data.data).to.deep.equal(res)
 				done()
 			})
 		})

--- a/test/api.error.test.js
+++ b/test/api.error.test.js
@@ -27,7 +27,7 @@ describe('api.error', function(){
 	//this.timeout(5000)
 	//this.slow(3000)
 
-	let freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
+	const freshdesk = new Freshdesk('https://test.freshdesk.com', 'TESTKEY')
 
 	describe('on API response status 400', () => {
 
@@ -44,7 +44,7 @@ describe('api.error', function(){
 				expect(err).to.be.instanceof(Freshdesk.FreshdeskError)
 				expect(err).has.property('status', 400)
 				expect(err).has.property('message', "Error in Freshdesk's client API")
-				expect(err).has.property('data').to.deep.equal({msg: "err 123"})
+				expect(err).has.property('data').to.deep.equal({data: {msg: "err 123"}})
 				expect(err).has.property('apiTarget').to.equal('GET https://test.freshdesk.com/api/v2/companies/2139')
 
 				done()

--- a/test/api.error.test.js
+++ b/test/api.error.test.js
@@ -44,7 +44,7 @@ describe('api.error', function(){
 				expect(err).to.be.instanceof(Freshdesk.FreshdeskError)
 				expect(err).has.property('status', 400)
 				expect(err).has.property('message', "Error in Freshdesk's client API")
-				expect(err).has.property('data').to.deep.equal({data: {msg: "err 123"}})
+				expect(err).has.property('data').to.deep.equal({msg: "err 123"})
 				expect(err).has.property('apiTarget').to.equal('GET https://test.freshdesk.com/api/v2/companies/2139')
 
 				done()

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -16,7 +16,7 @@ program. If not, see <https://opensource.org/licenses/MIT>.
 http://spdx.org/licenses/MIT
 */
 
-"use strict";
+"use strict"
 
-const chai = require("chai");
-global.expect = chai.expect;
+const chai = require("chai")
+global.expect = chai.expect

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -16,14 +16,14 @@ program. If not, see <https://opensource.org/licenses/MIT>.
 http://spdx.org/licenses/MIT
 */
 
-"use strict";
+"use strict"
 
-let freshdesk = require('..');
+let freshdesk = require('..')
 
 describe('module test', function(){
 
 	it('should export Freshdesk constructor', () => {
 
-		expect(freshdesk).to.be.a('function');
-	});
-});
+		expect(freshdesk).to.be.a('function')
+	})
+})


### PR DESCRIPTION
ref #15 

- Fixed: Eslint Warnings comply with `no-var`, `prefer-const` rule…(as per .eslintrc)
- Added   : `parse-link-header` module to parse pagination info from `response.headers`
- Updated :  
     wraps the responses inside `{data: []}` object to be able to attach
     pagination information from `headers.link` to the response data.