### PR TITLE
Expose manual request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -43,6 +43,50 @@ Freshdesk.prototype = Object.create({
 	 * @property {string} [updated_since]   Updated since.
 	 */
 
+
+  /**
+	 * Create a GET request to the freshDesk api
+   * @param {String} url - Url path excluding base path to the endpoint
+   * @param {Object} query - Query params to be sent
+   * @param callback
+   */
+	getRequest(url, query, callback) {
+		makeRequest('GET', this._auth, this.baseUri + url, query, null, callback);
+	},
+
+  /**
+   * Create a POST request to the freshDesk api
+   * @param {String} url - Url path excluding base path to the endpoint
+   * @param {Object} data - Data bo be sent with the request
+   * @param {Object} query - Query params to be sent
+   * @param callback
+   */
+	postRequest(url, query, data, callback) {
+		makeRequest('POST', this._auth, this.baseUri + url, query, data, callback);
+	},
+
+  /**
+   * Create a PUT request to the freshDesk api
+   * @param {String} url - Url path excluding base path to the endpoint
+   * @param {Object} data - Data bo be sent with the request
+   * @param {Object} query - Query params to be sent
+   * @param callback
+   */
+	putRequest(url, query, data, callback) {
+		makeRequest('PUT', this._auth, this.baseUri + url, query, data, callback);
+	},
+
+  /**
+   * Create a PUT request to the freshDesk api
+   * @param {String} url - Url path excluding base path to the endpoint
+   * @param {Object} data - Data bo be sent with the request
+   * @param {Object} query - Query params to be sent
+   * @param callback
+   */
+	deleteRequest(url, query, data, callback) {
+		makeRequest('DELETE', this._auth, this.baseUri + url, query, data, callback);
+	},
+
 	/**
 	 * listAllTickets API method
 	 * {@link http://developers.freshdesk.com/api/#list_all_tickets}

--- a/lib/client.js
+++ b/lib/client.js
@@ -54,8 +54,12 @@ Freshdesk.prototype = Object.create({
 		makeRequest('GET', this._auth, `${this.baseUrl}/api/v2/tickets`, params, null, cb)
 	},
 
-	listAllTicketFields(cb) {
-		makeRequest('GET', this._auth, `${this.baseUrl}/api/v2/ticket_fields`, null, null, cb)
+	listAllTicketFields(options, cb) {
+		const qs = options.type
+		? {type: options.type}
+		: null;
+
+		makeRequest('GET', this._auth, `${this.baseUrl}/api/v2/ticket_fields`, qs, null, cb)
 	},
 
 	createTicket(data, cb) {


### PR DESCRIPTION
The following features has been added:
* Add ticket type filtering for list all ticket fields
* Exposed manual `GET`, `POST`, `PUT` and `DELETE` methods for creating any manual requests that are not supported by the module.