### PR TITLE
Stringify data on error reply

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function FreshdeskError(message, data, res) {
 	this.message = message || 'Error in Freshdesk\'s client API'
 	this.stack = (new Error()).stack
 
-	this.data = data
+	this.data = JSON.stringify(data)
 
 	this.status = res.statusCode
 	this.apiTarget = `${res.request.method} ${res.request.uri.href}`


### PR DESCRIPTION
When I was trying to debug a validation error, I was receiving the not terribly useful message: 

      data: { description: 'Validation failed', errors: [ [Object] ] }

I was able to resolve with a simple stringify on the data and now get something like this:

      data: '{"description":"Validation failed","errors":[{"field":"type","message":"It should be one of these values: \'blah1,blah2,blah3\'","code":"missing_field"}]}',

which is much more useful. I don't expect the testing would need to be updated for this to pass.