### PR TITLE
rename API endpoint (Tickets -> tickets)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -65,7 +65,7 @@ class Freshdesk {
 	 * @return {Array.<Freshdesk.Tickets>}                  The array of tickets found
 	 */
 	listAllTickets (params, cb) {
-		makeRequest('GET', this._auth, `${this.baseUrl}/api/v2/Tickets`, params, null, cb)
+		makeRequest('GET', this._auth, `${this.baseUrl}/api/v2/tickets`, params, null, cb)
 	}
 
 	listAllTicketFields(params, cb) {


### PR DESCRIPTION
Currently it returns a 404