### PR TITLE
Fix custom fields and attachments form data

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -194,7 +194,14 @@ function makeRequest(method, auth, url, qs, data, cb) {		// eslint-disable-line 
 		const key = Object.keys(data)[i]
 		if (key === 'attachments') {
 			for (let i = 0; i < data[key].length; i++) {
-				form.append('attachments[]', data[key][i])
+				form.append('attachments[]', data[key][i].value, data[key][i].options)
+			}
+		} else if (key === 'custom_fields') {
+			const fields = Object.keys(data[key]);
+			for (const field of fields) {
+				if (!isNil(data[key][field])) {
+					form.append('custom_fields[' + field + ']', data[key][field])
+				}
 			}
 		} else {
 			form.append(key, data[key])


### PR DESCRIPTION
Hey @arjunkomath - thanks for making this project! 🥇 

We ran into some issues and had to make some changes:

* When submitting custom fields as form data, these would result in invalid fields being sent to the Freshdesk API, which would respond with status code 500 (internal_error / "We're sorry, but something went wrong."). This is now fixed with a properly nested object (only 1 level support).
* When submitting attachments using the current form data structure, the Freshdesk API would respond with status code 400 ("Validation failed", datatype_mismatch / "It should contain elements of type valid file format only"), suggesting it required some form of content type and perhaps filename to recognize the attachment. The attachments should now be an object with value of Readable(Stream) or Buffer and options with filename and contentType fields, e.g. `{ value: Buffer.from(fileBase64String, 'base64'), options: { filename: 'invoice.pdf', contentType: 'application/pdf' } }`.

This may require a major version bump due to the change for attachments. Only a Buffer value has been tested.