### PR TITLE
Fix form data

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,7 +156,10 @@ async function makeRequest(method, auth, url, qs, data, cb) {
 				}
 			}
 
-			options.headers["Content-Type"] = form.getHeaders()["content-type"];
+			options.headers["Content-Type"] =
+				typeof window === "undefined"
+					? form.getHeaders()["content-type"] // node
+					: "multipart/form-data"; // browser
 			options.data = form;
 		} else {
 			options.data = JSON.stringify(data);


### PR DESCRIPTION
Form data default to window.FormData when running inside browser, hence the getHeaders method is missing
Fixes #191 