### PR TITLE
fix: unexpected end of JSON input error when rate limit exceeded

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ async function makeRequest(method, auth, url, qs, data, cb) {
 
 	try {
 		const response = await request(url, options);
-		const data = (response.statusCode !== 204 && (response.headers["content-type"]?.startsWith("application/json"))) ? await response.body.json() : await response.body.text();
+		const data = (response.statusCode !== 204 && (response.headers["content-type"] && response.headers["content-type"].startsWith("application/json"))) ? await response.body.json() : await response.body.text();
 		return createResponseHandler(cb)(null, response, data, req);
 	} catch (error) {
 		const data = request.body;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ async function makeRequest(method, auth, url, qs, data, cb) {
 
 	try {
 		const response = await request(url, options);
-		const data = (response.statusCode !== 204 && (response.headers["content-type"] && response.headers["content-type"].startsWith("application/json"))) ? await response.body.json() : await response.body.text();
+		const data = (![204, 429].includes(response.statusCode) && (!response.headers["content-type"] || response.headers["content-type"].startsWith("application/json"))) ? await response.body.json() : await response.body.text();
 		return createResponseHandler(cb)(null, response, data, req);
 	} catch (error) {
 		const data = request.body;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ async function makeRequest(method, auth, url, qs, data, cb) {
 
 	try {
 		const response = await request(url, options);
-		const data = (response.statusCode !== 204 && (!response.headers["content-type"] || response.headers["content-type"].startsWith("application/json"))) ? await response.body.json() : await response.body.text();
+		const data = (response.statusCode !== 204 && (response.headers["content-type"]?.startsWith("application/json"))) ? await response.body.json() : await response.body.text();
 		return createResponseHandler(cb)(null, response, data, req);
 	} catch (error) {
 		const data = request.body;


### PR DESCRIPTION
* **This PR is a:**
    - [x] Bug fix

* **Description**
SyntaxError: Unexpected end of JSON input error is thrown when the rate limit is exceeded due to an error in parsing the response.
When the rate limit is exceeded the `response.body.json()` function throws an error because the response body is empty.